### PR TITLE
Ensure that A Touch of Magic LoadDictionary patch runs after Call Of The Wild

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -68,6 +68,7 @@ namespace ATouchOfMagic
             }
             return true;
         }
+        [Harmony12.HarmonyAfter("CallOfTheWild")]
         [Harmony12.HarmonyPatch(typeof(LibraryScriptableObject), "LoadDictionary")]
         [Harmony12.HarmonyPatch(typeof(LibraryScriptableObject), "LoadDictionary", new Type[0])]
         static class LibraryScriptableObject_LoadDictionary_Patch


### PR DESCRIPTION
Version 0.22.0 and later use Harmony 2.0 which can lead to a different patch sorting method being used and in some cases can cause A Touch of Magic to run before Call Of The Wild.